### PR TITLE
Add automatic expiration date setter

### DIFF
--- a/Examples/nginx.conf
+++ b/Examples/nginx.conf
@@ -53,7 +53,11 @@ http {
         # gzip_buffers 16 8k;
         # gzip_http_version 1.1;
         # gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
-
+        
+        # Importing automatic expiration date setter
+        js_import njs/securitytxt.js;
+        js_set $securityexpires securitytxt.setexpires;
+        
         # Mapping base hostname for security.txt, matches example.com or subdomain.example.com
         map $host      $basehost {
             default                    "";

--- a/security.txt.conf
+++ b/security.txt.conf
@@ -39,7 +39,7 @@ set $policy             "Policy: https://${basehost}/policy\n";
 #         Can have more than one (i.e. "Hiring: https://www.${basehost}/jobs\nHiring: https://jobs.${basehost}/\n")
 set $hiring             "Hiring: https://${basehost}/jobs\n";
 
-set $securitytxt "${contact}${encryption}${acknowledgements}${preferredlanguages}${canonical}${policy}${hiring}";
+set $securitytxt "${contact}${securityexpires}${encryption}${acknowledgements}${preferredlanguages}${canonical}${policy}${hiring}";
 
 location /.well-known/security.txt {
    add_header Content-Type text/plain;

--- a/securitytxt.js
+++ b/securitytxt.js
@@ -1,0 +1,23 @@
+function pad(number) {
+    var r = String(number);
+    if (r.length === 1) {
+    r = '0' + r;
+  }
+  return r;
+}
+//Modifying the prototype so it adds one year to expiration data
+Date.prototype.toISOString = function() {
+    return (this.getUTCFullYear() + 1) +
+    '-' + pad(this.getUTCMonth() + 1) +
+    '-' + pad(this.getUTCDate()) +
+    'T' + pad(this.getUTCHours()) +
+    ':' + pad(this.getUTCMinutes()) +
+    ':' + pad(this.getUTCSeconds()) +
+    '.' + String((this.getUTCMilliseconds() / 1000).toFixed(3)).slice(2, 5) +
+    'Z';
+}
+function setexpires(r) {
+var date = new Date();
+return ("Expires: " + date.toISOString() + "\n");
+}
+export default {setexpires};


### PR DESCRIPTION
`Expires:` field is required by security.txt specifications, so this PR makes your efforts compliant with it.

Also removed the part in the README where it is said that some configuration lines need to be before the includes, since all the configuration is loaded all at once, the order of directives doesn't matter